### PR TITLE
Fix fencepost error on AAAA display format

### DIFF
--- a/src/rdata.rs
+++ b/src/rdata.rs
@@ -247,7 +247,7 @@ impl fmt::Display for AAAAData {
             }
 
             sep = "::";
-            for quibble in quibbles[hi..quibbles.len()].iter() {
+            for quibble in quibbles[hi+1..quibbles.len()].iter() {
                 fmt_str.push_str(sep);
                 fmt_str.push_str(&format!("{:x}", quibble));
                 sep = ":";


### PR DESCRIPTION
The hi marker is the last zero, so it shouldn't be printed.